### PR TITLE
css: noscript compatibility with NoScript extension

### DIFF
--- a/haproxy.css
+++ b/haproxy.css
@@ -11,7 +11,7 @@ article > * {
 }
 article.js > *,
 article > h1,
-article > noscript {
+article > .noscript {
   display: inherit;
 }
 address {

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <body>
     <article v-scope @vue:mounted="mounted($el)">
       <h1>Debian/Ubuntu HAProxy packages</h1>
-      <noscript>
+      <noscript class="noscript">
         <p>
           This page requires JavaScript. Alternatively, for Debian, look at the
           list of


### PR DESCRIPTION
When using the [NoScript](https://noscript.net/) browser extension, at least in Firefox, the noscript HTML element gets replaced with a span element, making the `article > noscript` CSS selector unused and letting the noscript element hidden.

Using NoScript is the main reason for this site’s audience to potentially have scripting disabled nowadays.

This patch adds a `noscript` class and relies on that for the CSS selector. NoScript’s span element inherits it.